### PR TITLE
Disallow structs in buildFormFrom

### DIFF
--- a/packages/vue/src/form.ts
+++ b/packages/vue/src/form.ts
@@ -370,6 +370,7 @@ function buildFieldInfo(
 export const buildFormFromSchema = <
   From extends Record<PropertyKey, any>,
   To extends Record<PropertyKey, any>,
+  C extends Record<PropertyKey, any>,
   OnSubmitA
 >(
   s:
@@ -378,7 +379,7 @@ export const buildFormFromSchema = <
       From,
       never
     >
-    & { extend: any; fields: S.Struct.Fields },
+    & { new(c: C): any; extend: any; fields: S.Struct.Fields },
   state: Ref<Omit<From, "_tag">>,
   onSubmit: (a: To) => Promise<OnSubmitA>
 ) => {

--- a/packages/vue/src/form.ts
+++ b/packages/vue/src/form.ts
@@ -379,7 +379,7 @@ export const buildFormFromSchema = <
       From,
       never
     >
-    & { new(c: C): any; fields: S.Struct.Fields },
+    & { extend: any; fields: S.Struct.Fields },
   state: Ref<Omit<From, "_tag">>,
   onSubmit: (a: To) => Promise<OnSubmitA>
 ) => {

--- a/packages/vue/src/form.ts
+++ b/packages/vue/src/form.ts
@@ -370,7 +370,6 @@ function buildFieldInfo(
 export const buildFormFromSchema = <
   From extends Record<PropertyKey, any>,
   To extends Record<PropertyKey, any>,
-  C extends Record<PropertyKey, any>,
   OnSubmitA
 >(
   s:


### PR DESCRIPTION
This seems the way to disallow structs. They are classes too, you can instantiate them with `new` even it seems non-sensical to me. Anyway classes obtained by extending `S.Class` have an `extend` schema property, structs don't. I hope they never will.

Would fix #127 