### PR TITLE
R/mutation-query

### DIFF
--- a/.changeset/hungry-rice-march.md
+++ b/.changeset/hungry-rice-march.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue": minor
+---
+
+cleanup mutation helpers

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
   "typescript.preferences.includePackageJsonAutoImports": "on",
   "typescript.preferences.autoImportFileExcludePatterns": [
     "node_modules/@sentry/node",
+    "node_modules/vitest/dist",
     "node_modules/@azure/cosmos",
     "node_modules/effect-app/Schema",
     "node_modules/lodash",

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -8,7 +8,7 @@ import type { RequestHandler, RequestHandlerWithInput, TaggedRequestClassAny } f
 import { tuple } from "effect-app/Function"
 import type { ComputedRef, Ref } from "vue"
 import { computed, shallowRef } from "vue"
-import { makeQueryKey, reportRuntimeError } from "./lib.js"
+import { makeQueryKey } from "./lib.js"
 
 export const getQueryKey = (h: { name: string }) => {
   const key = makeQueryKey(h)
@@ -193,19 +193,13 @@ export const makeMutation = () => {
 
     const mapHandler = options?.mapHandler ?? ((_) => _)
 
-    const handle_ = (self: Effect<A, E, R>, i: I | void = void 0) => (mapHandler(
+    const handle = (self: Effect<A, E, R>, i: I | void = void 0) => (mapHandler(
       Effect.tapBoth(self, { onFailure: () => invalidateCache, onSuccess: () => invalidateCache }),
       i as I
     ) as Effect<A2, E2, R2>)
 
-    const handle = (self: Effect<A, E, R>, name: string, i: I | void = void 0) =>
-      handle_(self, i).pipe(
-        Effect.tapDefect(reportRuntimeError),
-        Effect.withSpan(`mutation ${name}`, { captureStackTrace: false })
-      )
-
     const handler = self.handler
-    const r = Effect.isEffect(handler) ? handle(handler, self.name) : (i: I) => handle(handler(i), self.name, i)
+    const r = Effect.isEffect(handler) ? handle(handler) : (i: I) => handle(handler(i), i)
 
     return r as any
   }

--- a/packages/vue/src/mutate.ts
+++ b/packages/vue/src/mutate.ts
@@ -149,7 +149,7 @@ export const makeMutation = () => {
     <I, E, A, R, Request extends TaggedRequestClassAny, A2 = A, E2 = E, R2 = R>(
       self: RequestHandlerWithInput<I, A, E, R, Request>,
       options?: MutationOptions<A, E, R, A2, E2, R2, I>
-    ): Effect<A2, E2, R2>
+    ): (i: I) => Effect<A2, E2, R2>
     <E, A, R, Request extends TaggedRequestClassAny, A2 = A, E2 = E, R2 = R>(
       self: RequestHandler<A, E, R, Request>,
       options?: MutationOptions<A, E, R, A2, E2, R2>


### PR DESCRIPTION
- make sure we only report defects once
- make sure we report defects from inside the unsafe part of mutations
- do not report error processing errors manually, they will be picked up by error reporters automatically on run failure.