### PR TITLE
Exclusive queries

### DIFF
--- a/.changeset/rotten-actors-raise.md
+++ b/.changeset/rotten-actors-raise.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/infra": minor
+---
+
+add exclusive queries

--- a/packages/infra/src/Model/Repository/service.ts
+++ b/packages/infra/src/Model/Repository/service.ts
@@ -2,7 +2,7 @@
 import type { Effect, Option, PubSub, S } from "effect-app"
 import type { InvalidStateError, NotFoundError, OptimisticConcurrencyException } from "effect-app/client/errors"
 import type { NonNegativeInt } from "effect-app/Schema/numbers"
-import type { FieldValues, ResolveFirstLevel } from "../filter/types.js"
+import type { FieldValues, IsNever, ResolveFirstLevel } from "../filter/types.js"
 import type { QAll, Query, QueryProjection } from "../query.js"
 import type { Mapped } from "./legacy.js"
 
@@ -35,30 +35,12 @@ export interface Repository<
       A,
       R,
       From extends FieldValues,
-      TType extends "one" | "many" | "count" = "many"
+      TType extends "one" | "many" | "count" = "many",
+      E extends boolean = false
     >(
       q: (
         initial: Query<Encoded>
-      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
-    ): Effect.Effect<
-      TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
-      | (TType extends "many" ? never : NotFoundError<ItemType>)
-      | (TType extends "count" ? never : S.ParseResult.ParseError),
-      R | RSchema
-    >
-    <
-      A,
-      R,
-      From extends FieldValues,
-      TType extends "one" | "many" | "count" = "many",
-      $A = never
-    >(
-      q1: (
-        initial: Query<Encoded>
-      ) => $A,
-      q2: (
-        _: $A
-      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -71,15 +53,14 @@ export interface Repository<
       From extends FieldValues,
       TType extends "one" | "many" | "count" = "many",
       $A = never,
-      $B = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
       ) => $A,
-      q2: (_: $A) => $B,
-      q3: (
-        _: $B
-      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q2: (
+        _: $A
+      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -93,16 +74,15 @@ export interface Repository<
       TType extends "one" | "many" | "count" = "many",
       $A = never,
       $B = never,
-      $C = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
       ) => $A,
       q2: (_: $A) => $B,
-      q3: (_: $B) => $C,
-      q4: (
-        _: $C
-      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q3: (
+        _: $B
+      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -117,17 +97,16 @@ export interface Repository<
       $A = never,
       $B = never,
       $C = never,
-      $D = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
       ) => $A,
       q2: (_: $A) => $B,
       q3: (_: $B) => $C,
-      q4: (_: $C) => $D,
-      q5: (
-        _: $D
-      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q4: (
+        _: $C
+      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -143,7 +122,7 @@ export interface Repository<
       $B = never,
       $C = never,
       $D = never,
-      $E = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
@@ -151,8 +130,9 @@ export interface Repository<
       q2: (_: $A) => $B,
       q3: (_: $B) => $C,
       q4: (_: $C) => $D,
-      q5: (_: $D) => $E,
-      q6: (_: $E) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q5: (
+        _: $D
+      ) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -169,7 +149,7 @@ export interface Repository<
       $C = never,
       $D = never,
       $E = never,
-      $F = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
@@ -178,8 +158,7 @@ export interface Repository<
       q3: (_: $B) => $C,
       q4: (_: $C) => $D,
       q5: (_: $D) => $E,
-      q6: (_: $E) => $F,
-      q7: (_: $F) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q6: (_: $E) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -197,7 +176,7 @@ export interface Repository<
       $D = never,
       $E = never,
       $F = never,
-      $G = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
@@ -207,8 +186,7 @@ export interface Repository<
       q4: (_: $C) => $D,
       q5: (_: $D) => $E,
       q6: (_: $E) => $F,
-      q7: (_: $F) => $G,
-      q8: (_: $G) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q7: (_: $F) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -227,7 +205,7 @@ export interface Repository<
       $E = never,
       $F = never,
       $G = never,
-      $H = never
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
@@ -238,8 +216,7 @@ export interface Repository<
       q5: (_: $D) => $E,
       q6: (_: $E) => $F,
       q7: (_: $F) => $G,
-      q8: (_: $G) => $H,
-      q9: (_: $H) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q8: (_: $G) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -259,7 +236,40 @@ export interface Repository<
       $F = never,
       $G = never,
       $H = never,
-      $I = never
+      E extends boolean = false
+    >(
+      q1: (
+        initial: Query<Encoded>
+      ) => $A,
+      q2: (_: $A) => $B,
+      q3: (_: $B) => $C,
+      q4: (_: $C) => $D,
+      q5: (_: $D) => $E,
+      q6: (_: $E) => $F,
+      q7: (_: $F) => $G,
+      q8: (_: $G) => $H,
+      q9: (_: $H) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
+    ): Effect.Effect<
+      TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
+      | (TType extends "many" ? never : NotFoundError<ItemType>)
+      | (TType extends "count" ? never : S.ParseResult.ParseError),
+      R | RSchema
+    >
+    <
+      A,
+      R,
+      From extends FieldValues,
+      TType extends "one" | "many" | "count" = "many",
+      $A = never,
+      $B = never,
+      $C = never,
+      $D = never,
+      $E = never,
+      $F = never,
+      $G = never,
+      $H = never,
+      $I = never,
+      E extends boolean = false
     >(
       q1: (
         initial: Query<Encoded>
@@ -272,7 +282,7 @@ export interface Repository<
       q7: (_: $F) => $G,
       q8: (_: $G) => $H,
       q9: (_: $H) => $I,
-      q10: (_: $I) => QueryProjection<From extends Encoded ? From : never, A, R, TType>
+      q10: (_: $I) => QueryProjection<From extends Encoded ? From : never, A, R, TType, E>
     ): Effect.Effect<
       TType extends "many" ? readonly A[] : TType extends "count" ? NonNegativeInt : A,
       | (TType extends "many" ? never : NotFoundError<ItemType>)
@@ -284,26 +294,12 @@ export interface Repository<
     <
       R = never,
       TType extends "one" | "many" = "many",
-      EncodedRefined extends Encoded = Encoded
-    >(
-      q: (initial: Query<Encoded>) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
-    ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
-      TType extends "many" ? never : NotFoundError<ItemType>,
-      R | RSchema
-    >
-    <
-      R = never,
-      TType extends "one" | "many" = "many",
       EncodedRefined extends Encoded = Encoded,
-      $A = never
+      E extends boolean = false
     >(
-      q1: (initial: Query<Encoded>) => $A,
-      q2: (
-        _: $A
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q: (initial: Query<Encoded>) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -312,17 +308,14 @@ export interface Repository<
       TType extends "one" | "many" = "many",
       EncodedRefined extends Encoded = Encoded,
       $A = never,
-      $B = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (
         _: $A
-      ) => $B,
-      q3: (
-        _: $B
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -332,16 +325,17 @@ export interface Repository<
       EncodedRefined extends Encoded = Encoded,
       $A = never,
       $B = never,
-      $C = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
-      q2: (_: $A) => $B,
-      q3: (_: $B) => $C,
-      q4: (
-        _: $C
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q2: (
+        _: $A
+      ) => $B,
+      q3: (
+        _: $B
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -352,17 +346,16 @@ export interface Repository<
       $A = never,
       $B = never,
       $C = never,
-      $D = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (_: $A) => $B,
       q3: (_: $B) => $C,
-      q4: (_: $C) => $D,
-      q5: (
-        _: $D
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q4: (
+        _: $C
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -374,18 +367,17 @@ export interface Repository<
       $B = never,
       $C = never,
       $D = never,
-      $E = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (_: $A) => $B,
       q3: (_: $B) => $C,
       q4: (_: $C) => $D,
-      q5: (_: $D) => $E,
-      q6: (
-        _: $E
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q5: (
+        _: $D
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -398,19 +390,18 @@ export interface Repository<
       $C = never,
       $D = never,
       $E = never,
-      $F = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (_: $A) => $B,
       q3: (_: $B) => $C,
       q4: (_: $C) => $D,
       q5: (_: $D) => $E,
-      q6: (_: $E) => $F,
-      q7: (
-        _: $F
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q6: (
+        _: $E
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -424,7 +415,7 @@ export interface Repository<
       $D = never,
       $E = never,
       $F = never,
-      $G = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (_: $A) => $B,
@@ -432,12 +423,11 @@ export interface Repository<
       q4: (_: $C) => $D,
       q5: (_: $D) => $E,
       q6: (_: $E) => $F,
-      q7: (_: $F) => $G,
-      q8: (
-        _: $G
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q7: (
+        _: $F
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined> : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -452,7 +442,7 @@ export interface Repository<
       $E = never,
       $F = never,
       $G = never,
-      $H = never
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (_: $A) => $B,
@@ -461,12 +451,12 @@ export interface Repository<
       q5: (_: $D) => $E,
       q6: (_: $E) => $F,
       q7: (_: $F) => $G,
-      q8: (_: $G) => $H,
-      q9: (
-        _: $H
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      q8: (
+        _: $G
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined>
+        : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -482,7 +472,39 @@ export interface Repository<
       $F = never,
       $G = never,
       $H = never,
-      $I = never
+      E extends boolean = false
+    >(
+      q1: (initial: Query<Encoded>) => $A,
+      q2: (_: $A) => $B,
+      q3: (_: $B) => $C,
+      q4: (_: $C) => $D,
+      q5: (_: $D) => $E,
+      q6: (_: $E) => $F,
+      q7: (_: $F) => $G,
+      q8: (_: $G) => $H,
+      q9: (
+        _: $H
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
+    ): Effect.Effect<
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined>
+        : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? never : NotFoundError<ItemType>,
+      R | RSchema
+    >
+    <
+      R = never,
+      TType extends "one" | "many" = "many",
+      EncodedRefined extends Encoded = Encoded,
+      $A = never,
+      $B = never,
+      $C = never,
+      $D = never,
+      $E = never,
+      $F = never,
+      $G = never,
+      $H = never,
+      $I = never,
+      E extends boolean = false
     >(
       q1: (initial: Query<Encoded>) => $A,
       q2: (_: $A) => $B,
@@ -495,9 +517,10 @@ export interface Repository<
       q9: (_: $H) => $I,
       q10: (
         _: $I
-      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType>
+      ) => QAll<Encoded, EncodedRefined, RefineTHelper<T, EncodedRefined>, R, TType, E>
     ): Effect.Effect<
-      TType extends "many" ? readonly RefineTHelper<T, EncodedRefined>[] : RefineTHelper<T, EncodedRefined>,
+      TType extends "many" ? DistributeQueryIfExclusiveOnArray<E, T, EncodedRefined>
+        : RefineTHelper<T, EncodedRefined>,
       TType extends "many" ? never : NotFoundError<ItemType>,
       R | RSchema
     >
@@ -506,6 +529,13 @@ export interface Repository<
   /** @deprecated use query */
   readonly mapped: Mapped<Encoded>
 }
+
+type DistributeQueryIfExclusiveOnArray<Exclusive extends boolean, T, EncodedRefined> = [Exclusive] extends [true]
+  ? T extends any ? RefineTHelper<T, EncodedRefined> extends infer R ? IsNever<R> extends true ? never
+      : readonly R[]
+    : never
+  : never
+  : readonly RefineTHelper<T, EncodedRefined>[]
 
 type NullableRefined<T, EncodedRefined> = {
   // EncodedRefined may be a union, so if you just keyof you'll get just common keys

--- a/packages/infra/test/query.test.ts
+++ b/packages/infra/test/query.test.ts
@@ -914,9 +914,6 @@ it("distribution over union", () =>
         where("_tag", Math.random() > 0.5 ? "animal" : "person")
       )
 
-      // to be safe I will enable that just for _tag that is an exclusive field
-      // but how could I know at the end I did a refinement on _tag?
-      // because single applications of where, and work on the single result, not on array
       expectTypeOf(res).toEqualTypeOf<
         | readonly ({
           readonly id: string


### PR DESCRIPTION
When filtering with `_tag` the query goes in a _exclusive_ mode, when appropriate. This is useful for queries that return arrays over discriminated stuff.

If we have `type U = A | B | C` and we do a query with `_tag = "A" | "B"` the result will be `A[] | B[]` instead of `(A | B)[]`