### PR TITLE
Fixes meta.required wrong inheritance and adds at least storybook story, waiting for unit tests

### DIFF
--- a/.changeset/orange-steaks-grin.md
+++ b/.changeset/orange-steaks-grin.md
@@ -1,0 +1,5 @@
+---
+"@effect-app/vue-components": patch
+---
+
+Fixes meta.required wrong inheritance and adds at least storybook story, waiting for unit tests

--- a/packages/vue-components/src/components/OmegaForm/OmegaFormStuff.ts
+++ b/packages/vue-components/src/components/OmegaForm/OmegaFormStuff.ts
@@ -218,6 +218,16 @@ const isNullableOrUndefined = (property: false | S.AST.AST | undefined) => {
   return false
 }
 
+const isRequiredFromNullableOrUndefined = (
+  property: false | S.AST.AST | undefined,
+) => {
+  if (!property || !S.AST.isUnion(property)) return false
+  if (property.types.find(_ => _._tag === "UndefinedKeyword"))
+    return "undefined"
+  if (property.types.find(_ => _ === S.Null.ast)) return "null"
+  return false
+}
+
 const createMeta = <T = any>(
   { meta = {}, parent = "", property, propertySignatures }: CreateMeta,
   acc: Partial<MetaRecord<T>> = {},
@@ -241,7 +251,7 @@ const createMeta = <T = any>(
     for (const p of propertySignatures) {
       const key = parent ? `${parent}.${p.name.toString()}` : p.name.toString()
       const nullableOrUndefined = isNullableOrUndefined(p.type)
-      const isRequired = meta["required"] ?? !nullableOrUndefined
+      const isRequired = !nullableOrUndefined
 
       let typeToProcess = p.type
       if (S.AST.isUnion(p.type)) {
@@ -275,7 +285,8 @@ const createMeta = <T = any>(
     const nullableOrUndefined = getNullableOrUndefined(property)
 
     if (!Object.hasOwnProperty.call(meta, "required")) {
-      meta["required"] = !nullableOrUndefined
+      meta["required"] =
+        typeof nullableOrUndefined !== "string" && !nullableOrUndefined
     }
 
     if (S.AST.isUnion(property)) {

--- a/packages/vue-components/src/components/OmegaForm/OmegaFormStuff.ts
+++ b/packages/vue-components/src/components/OmegaForm/OmegaFormStuff.ts
@@ -218,16 +218,6 @@ const isNullableOrUndefined = (property: false | S.AST.AST | undefined) => {
   return false
 }
 
-const isRequiredFromNullableOrUndefined = (
-  property: false | S.AST.AST | undefined,
-) => {
-  if (!property || !S.AST.isUnion(property)) return false
-  if (property.types.find(_ => _._tag === "UndefinedKeyword"))
-    return "undefined"
-  if (property.types.find(_ => _ === S.Null.ast)) return "null"
-  return false
-}
-
 const createMeta = <T = any>(
   { meta = {}, parent = "", property, propertySignatures }: CreateMeta,
   acc: Partial<MetaRecord<T>> = {},
@@ -285,8 +275,7 @@ const createMeta = <T = any>(
     const nullableOrUndefined = getNullableOrUndefined(property)
 
     if (!Object.hasOwnProperty.call(meta, "required")) {
-      meta["required"] =
-        typeof nullableOrUndefined !== "string" && !nullableOrUndefined
+      meta["required"] = !nullableOrUndefined
     }
 
     if (S.AST.isUnion(property)) {

--- a/packages/vue-components/src/stories/OmegaForm.stories.ts
+++ b/packages/vue-components/src/stories/OmegaForm.stories.ts
@@ -9,6 +9,7 @@ import ComplexForm from "./OmegaForm/ComplexForm.vue"
 import SimpleFormVuetifyDefault from "./OmegaForm/SimpleFormVuetifyDefault.vue"
 import SumExample from "./OmegaForm/SumExample.vue"
 import PersistencyForm from "./OmegaForm/PersistencyForm.vue"
+import MetaForm from "./OmegaForm/Meta.vue"
 
 const mockIntl = {
   locale: ref("en"),
@@ -79,5 +80,12 @@ export const PersistencyFormStory: Story = {
   render: () => ({
     components: { PersistencyForm },
     template: "<PersistencyForm />",
+  }),
+}
+
+export const MetaStory: Story = {
+  render: () => ({
+    components: { MetaForm },
+    template: "<MetaForm />",
   }),
 }

--- a/packages/vue-components/src/stories/OmegaForm/Meta.vue
+++ b/packages/vue-components/src/stories/OmegaForm/Meta.vue
@@ -1,0 +1,47 @@
+<template>
+  <OmegaForm
+    :schema="
+      S.Struct({
+        a: S.NullOr(S.String),
+        b: S.UndefinedOr(S.Number),
+        c: S.NullishOr(S.Number),
+        d: S.String,
+        e: S.Number,
+        f: S.Number,
+        struct: S.Struct({
+          a: S.NullOr(S.String),
+          b: S.UndefinedOr(S.Number),
+          c: S.NullishOr(S.Number),
+          d: S.String,
+          e: S.Number,
+          f: S.Number,
+        }),
+      })
+    "
+  >
+    <template #default="{ form }">
+      <ul>
+        <li v-for="key in Object.keys(form.meta)" :key="key">
+          {{ key }}: {{ (form.meta as any)[key] }}
+        </li>
+      </ul>
+      <OmegaInput label="a" :form="form" name="a" />
+      <OmegaInput label="b" :form="form" name="b" />
+      <OmegaInput label="c" :form="form" name="c" />
+      <OmegaInput label="d" :form="form" name="d" />
+      <OmegaInput label="e" :form="form" name="e" />
+      <OmegaInput label="f" :form="form" name="f" />
+      <OmegaInput label="struct.a" :form="form" name="struct.a" />
+      <OmegaInput label="struct.b" :form="form" name="struct.b" />
+      <OmegaInput label="struct.c" :form="form" name="struct.c" />
+      <OmegaInput label="struct.d" :form="form" name="struct.d" />
+      <OmegaInput label="struct.e" :form="form" name="struct.e" />
+      <OmegaInput label="struct.f" :form="form" name="struct.f" />
+    </template>
+  </OmegaForm>
+</template>
+
+<script setup lang="ts">
+import { OmegaForm, OmegaInput } from "../../components/OmegaForm"
+import { S } from "effect-app"
+</script>


### PR DESCRIPTION
When a Schema structure had an optional leaf, the optionality was overwritten by the parent meta.required. This was intentionally done at the beginning, but it was obviously the wrong call. 