### PR TITLE
ci: do not block Changesets version on snapshot publish

### DIFF
--- a/.changeset/version-independent-snapshot.md
+++ b/.changeset/version-independent-snapshot.md
@@ -1,0 +1,5 @@
+---
+
+---
+
+Run Changesets version in parallel with pkg.pr.new snapshot publish on main.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
   workflow_call:
+    inputs:
+      publish_snapshot:
+        description: Run snapshot publish inside this reusable workflow
+        type: boolean
+        default: false
   workflow_dispatch:
 
 env:
@@ -142,95 +147,18 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  # On main, Changesets calls this workflow and then runs `version` with
+  # `needs: [ci]`. Keep snapshot out of that reusable path so version does
+  # not wait for pkg.pr.new. Main snapshot runs as a sibling in release.yaml.
   snapshot:
     name: Publish Snapshot
     needs: [build]
     if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, 'chore: update versions')) ||
+      inputs.publish_snapshot ||
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
       github.event_name == 'workflow_dispatch'
-    timeout-minutes: 20
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: latest
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-output
-          path: packages/
-
-      - name: Publish snapshots to pkg.pr.new
-        id: publish
-        run: pnpm exec pkg-pr-new publish --pnpm ./packages/*
-
-      - name: Write snapshot usage summary
-        id: usage
-        shell: bash
-        run: |
-          PACKAGE_LOCATORS="${{ steps.publish.outputs.packages }}"
-          PACKAGE_URLS="${{ steps.publish.outputs.urls }}"
-          PUBLISHED_SHA="${{ steps.publish.outputs.sha }}"
-          if [ -z "$PACKAGE_LOCATORS" ] || [ -z "$PACKAGE_URLS" ] || [ -z "$PUBLISHED_SHA" ]; then
-            echo "pkg-pr-new did not return expected outputs (packages/urls/sha)" >&2
-            exit 1
-          fi
-
-          {
-            echo "## Snapshot publish complete"
-            echo
-            echo "- SHA: \`${PUBLISHED_SHA}\`"
-            echo
-            echo "Published via pkg.pr.new."
-            echo
-            echo "### Install package locators"
-            echo "\`\`\`bash"
-            echo "$PACKAGE_LOCATORS"
-            echo "\`\`\`"
-            echo
-            echo "### Package URLs"
-            echo "\`\`\`text"
-            echo "$PACKAGE_URLS"
-            echo "\`\`\`"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          {
-            echo "package_locators<<EOF"
-            echo "$PACKAGE_LOCATORS"
-            echo "EOF"
-            echo "package_urls<<EOF"
-            echo "$PACKAGE_URLS"
-            echo "EOF"
-            echo "published_sha=$PUBLISHED_SHA"
-          } >> "$GITHUB_OUTPUT"
+    uses: ./.github/workflows/publish-snapshot.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets: inherit

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,100 @@
+name: Publish Snapshot
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CI: true
+
+jobs:
+  snapshot:
+    name: Publish Snapshot
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: latest
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-output
+          path: packages/
+
+      - name: Publish snapshots to pkg.pr.new
+        id: publish
+        run: pnpm exec pkg-pr-new publish --pnpm ./packages/*
+
+      - name: Write snapshot usage summary
+        id: usage
+        shell: bash
+        run: |
+          PACKAGE_LOCATORS="${{ steps.publish.outputs.packages }}"
+          PACKAGE_URLS="${{ steps.publish.outputs.urls }}"
+          PUBLISHED_SHA="${{ steps.publish.outputs.sha }}"
+          if [ -z "$PACKAGE_LOCATORS" ] || [ -z "$PACKAGE_URLS" ] || [ -z "$PUBLISHED_SHA" ]; then
+            echo "pkg-pr-new did not return expected outputs (packages/urls/sha)" >&2
+            exit 1
+          fi
+
+          {
+            echo "## Snapshot publish complete"
+            echo
+            echo "- SHA: \`${PUBLISHED_SHA}\`"
+            echo
+            echo "Published via pkg.pr.new."
+            echo
+            echo "### Install package locators"
+            echo "\`\`\`bash"
+            echo "$PACKAGE_LOCATORS"
+            echo "\`\`\`"
+            echo
+            echo "### Package URLs"
+            echo "\`\`\`text"
+            echo "$PACKAGE_URLS"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "package_locators<<EOF"
+            echo "$PACKAGE_LOCATORS"
+            echo "EOF"
+            echo "package_urls<<EOF"
+            echo "$PACKAGE_URLS"
+            echo "EOF"
+            echo "published_sha=$PUBLISHED_SHA"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,18 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
 
+  snapshot:
+    name: Publish Snapshot
+    needs: [ci]
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !contains(github.event.head_commit.message, 'chore: update versions')
+    uses: ./.github/workflows/publish-snapshot.yml
+    permissions:
+      contents: read
+      pull-requests: write
+    secrets: inherit
+
   version:
     needs: [ci]
     timeout-minutes: 15


### PR DESCRIPTION
## Summary

On `main`, Changesets calls the reusable CI workflow and then runs `version` with `needs: [ci]`. Publish Snapshot lived inside that reusable workflow, so version waited on pkg.pr.new even though the two jobs do not depend on each other.

Snapshot is now its own reusable workflow:

- **PRs / workflow_dispatch:** still publish after `build` (lint/test stay parallel).
- **main (`release.yaml`):** `snapshot` and `version` both `needs: [ci]`, so they start together after lint/build/test.

Version still waits for the quality gates. It no longer waits for snapshot success or failure.

## Test plan

- [ ] PR CI still runs Lint, Build, Test, and Publish Snapshot after build
- [ ] On the next `main` push (non-version-bump, non-bot), Changesets shows `snapshot` and `version` as siblings after `ci`
- [ ] A snapshot failure must not prevent `version` from starting
- [ ] Version-bump commits (`chore: update versions`) still skip snapshot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/effect-app/codesmith/libs/pr/866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789280983&installation_model_id=428864&pr_number=866&repository=effect-app%2Flibs&return_to=https%3A%2F%2Fgithub.com%2Feffect-app%2Flibs%2Fpull%2F866&signature=03cc9b84dbd791823fb5b3a873c93945689e078a93f6fe82bf38eb45ce3459f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->